### PR TITLE
Fix/#31 AppleMusicPlaylistViewController Songs Fetch

### DIFF
--- a/Mapli/Mapli.xcodeproj/project.pbxproj
+++ b/Mapli/Mapli.xcodeproj/project.pbxproj
@@ -35,6 +35,7 @@
 		E2821A60289A472000982AE7 /* UIImage+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2821A5F289A472000982AE7 /* UIImage+.swift */; };
 		E2821A62289B97A500982AE7 /* TemplatesCollectionViewCell.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2821A61289B97A500982AE7 /* TemplatesCollectionViewCell.swift */; };
 		E2AD46C4289BA4AC00E513B7 /* TemplatesModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2AD46C3289BA4AC00E513B7 /* TemplatesModel.swift */; };
+		E2AD46C6289C46A900E513B7 /* UIImageView+.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2AD46C5289C46A900E513B7 /* UIImageView+.swift */; };
 /* End PBXBuildFile section */
 
 /* Begin PBXFileReference section */
@@ -68,6 +69,7 @@
 		E2821A5F289A472000982AE7 /* UIImage+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImage+.swift"; sourceTree = "<group>"; };
 		E2821A61289B97A500982AE7 /* TemplatesCollectionViewCell.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplatesCollectionViewCell.swift; sourceTree = "<group>"; };
 		E2AD46C3289BA4AC00E513B7 /* TemplatesModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = TemplatesModel.swift; sourceTree = "<group>"; };
+		E2AD46C5289C46A900E513B7 /* UIImageView+.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "UIImageView+.swift"; sourceTree = "<group>"; };
 /* End PBXFileReference section */
 
 /* Begin PBXFrameworksBuildPhase section */
@@ -193,6 +195,7 @@
 			children = (
 				E2821A5B2897FB6800982AE7 /* UIScreen+.swift */,
 				E2821A5F289A472000982AE7 /* UIImage+.swift */,
+				E2AD46C5289C46A900E513B7 /* UIImageView+.swift */,
 			);
 			path = Extension;
 			sourceTree = "<group>";
@@ -282,6 +285,7 @@
 				E2194442289577AB005BE37B /* Mapli++Bundle.swift in Sources */,
 				E2AD46C4289BA4AC00E513B7 /* TemplatesModel.swift in Sources */,
 				E2821A62289B97A500982AE7 /* TemplatesCollectionViewCell.swift in Sources */,
+				E2AD46C6289C46A900E513B7 /* UIImageView+.swift in Sources */,
 				E2821A5E2899976C00982AE7 /* CustomTapGesture.swift in Sources */,
 				E21D9968288ABA580065CB2A /* MainViewController.swift in Sources */,
 				8E556EAE289BEAEA008E6D97 /* MainCollectionViewCell.swift in Sources */,

--- a/Mapli/Mapli/Resources/Storyboards/AppleMusicPlaylist.storyboard
+++ b/Mapli/Mapli/Resources/Storyboards/AppleMusicPlaylist.storyboard
@@ -57,6 +57,7 @@
                                         <connections>
                                             <outlet property="playlistImage" destination="lTt-ed-HpK" id="tDM-5d-fvW"/>
                                             <outlet property="playlistLabel" destination="ZP7-KZ-8rf" id="ny9-mo-ZaJ"/>
+                                            <segue destination="nab-s9-fRd" kind="show" identifier="SongSelectionSegue" id="ga4-DG-MrX"/>
                                         </connections>
                                     </collectionViewCell>
                                 </cells>
@@ -81,6 +82,16 @@
                 <placeholder placeholderIdentifier="IBFirstResponder" id="Ief-a0-LHa" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
             </objects>
             <point key="canvasLocation" x="31.884057971014496" y="93.75"/>
+        </scene>
+        <!--SongSelectionStoryboard-->
+        <scene sceneID="GfS-6M-N3v">
+            <objects>
+                <viewControllerPlaceholder storyboardIdentifier="SongSelectionVC" storyboardName="SongSelectionStoryboard" id="nab-s9-fRd" sceneMemberID="viewController">
+                    <navigationItem key="navigationItem" id="zYg-FJ-aI1"/>
+                </viewControllerPlaceholder>
+                <placeholder placeholderIdentifier="IBFirstResponder" id="PJ2-p8-XCo" userLabel="First Responder" customClass="UIResponder" sceneMemberID="firstResponder"/>
+            </objects>
+            <point key="canvasLocation" x="754" y="94"/>
         </scene>
     </scenes>
     <resources>

--- a/Mapli/Mapli/Resources/Storyboards/AppleMusicPlaylist.storyboard
+++ b/Mapli/Mapli/Resources/Storyboards/AppleMusicPlaylist.storyboard
@@ -45,9 +45,9 @@
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
                                                 </imageView>
                                                 <label opaque="NO" userInteractionEnabled="NO" contentMode="left" horizontalHuggingPriority="251" verticalHuggingPriority="251" fixedFrame="YES" text="운동할 때" textAlignment="natural" lineBreakMode="tailTruncation" baselineAdjustment="alignBaselines" adjustsFontSizeToFit="NO" translatesAutoresizingMaskIntoConstraints="NO" id="ZP7-KZ-8rf">
-                                                    <rect key="frame" x="0.0" y="178" width="170" height="23"/>
+                                                    <rect key="frame" x="0.0" y="171" width="170" height="23"/>
                                                     <autoresizingMask key="autoresizingMask" flexibleMaxX="YES" flexibleMaxY="YES"/>
-                                                    <fontDescription key="fontDescription" type="system" pointSize="17"/>
+                                                    <fontDescription key="fontDescription" type="system" pointSize="18"/>
                                                     <nil key="textColor"/>
                                                     <nil key="highlightedColor"/>
                                                 </label>

--- a/Mapli/Mapli/Sources/Classes/AppleMusicAPI.swift
+++ b/Mapli/Mapli/Sources/Classes/AppleMusicAPI.swift
@@ -27,7 +27,7 @@ class AppleMusicAPI {
         return playlists.data
 	}
 	
-	func fetchSongs(userToken: String, id: String) async throws -> [MySong] {
+	func fetchMySongs(userToken: String, id: String) async throws -> [MySong] {
 		guard let musicURL = URL(string: "https://api.music.apple.com/v1/me/library/playlists/\(id)/tracks") else { throw NetworkError.invalidURL }
 		var musicRequest = URLRequest(url: musicURL)
 		musicRequest.httpMethod = "GET"
@@ -41,5 +41,17 @@ class AppleMusicAPI {
 			mySongs.append(MySong(title: song.attributes.name, isCheck: false))
 		}
 		return mySongs
+	}
+	
+	func fetchSongs(userToken: String, id: String) async throws -> [Song] {
+		guard let musicURL = URL(string: "https://api.music.apple.com/v1/me/library/playlists/\(id)/tracks") else { throw NetworkError.invalidURL }
+		var musicRequest = URLRequest(url: musicURL)
+		musicRequest.httpMethod = "GET"
+		musicRequest.addValue("Bearer \(developerToken)", forHTTPHeaderField: "Authorization")
+		musicRequest.addValue(userToken, forHTTPHeaderField: "Music-User-Token")
+		
+		let (data, _) = try await URLSession.shared.data(for: musicRequest)
+		let songs = try JSONDecoder().decode(SongDatum.self, from: data)
+		return songs.data
 	}
 }

--- a/Mapli/Mapli/Sources/Classes/AppleMusicAPI.swift
+++ b/Mapli/Mapli/Sources/Classes/AppleMusicAPI.swift
@@ -38,7 +38,7 @@ class AppleMusicAPI {
 		let songs = try JSONDecoder().decode(SongDatum.self, from: data)
 		var mySongs = [MySong]()
 		for song in songs.data {
-			mySongs.append(MySong(title: song.attributes.name, isCheck: false))
+			mySongs.append(MySong(title: song.attributes.name, imageURL: song.attributes.artwork.url, id: id, width: song.attributes.artwork.width, height: song.attributes.artwork.height, isCheck: false))
 		}
 		return mySongs
 	}

--- a/Mapli/Mapli/Sources/Classes/AppleMusicViewModel.swift
+++ b/Mapli/Mapli/Sources/Classes/AppleMusicViewModel.swift
@@ -38,7 +38,6 @@ extension AppleMusicViewModel {
 			do {
 				self.usetToken = try await AppleMusicAPI().fetchUserToken()
 				self.playlists = try await AppleMusicAPI().fetchPlaylists(userToken: usetToken)
-				self.mySongs = try await AppleMusicAPI().fetchMySongs(userToken: usetToken, id: playlists[0].id)
 			} catch NetworkError.invalidURL {
 				print("Invalid URL ERROR!")
 			}
@@ -49,6 +48,16 @@ extension AppleMusicViewModel {
 		Task {
 			do {
 				self.songs = try await AppleMusicAPI().fetchSongs(userToken: usetToken, id: playlistId)
+			} catch NetworkError.invalidURL {
+				print("Invalid URL ERROR!")
+			}
+		}
+	}
+	
+	func fetchMySong(playlistId: String) {
+		Task {
+			do {
+				self.mySongs = try await AppleMusicAPI().fetchMySongs(userToken: usetToken, id: playlistId)
 			} catch NetworkError.invalidURL {
 				print("Invalid URL ERROR!")
 			}

--- a/Mapli/Mapli/Sources/Classes/AppleMusicViewModel.swift
+++ b/Mapli/Mapli/Sources/Classes/AppleMusicViewModel.swift
@@ -9,9 +9,10 @@ import Combine
 import Foundation
 import StoreKit
 
-final class AppleMusicViewModel: ObservableObject {
+class AppleMusicViewModel: ObservableObject {
 	@Published var mySongs = [MySong]()
 	@Published var playlists = [Playlist]()
+	@Published var songs = [Song]()
 	var usetToken = String()
 
 	init() {
@@ -31,14 +32,23 @@ final class AppleMusicViewModel: ObservableObject {
 	}
 }
 
-private extension AppleMusicViewModel {
+extension AppleMusicViewModel {
 	func fetchAPI() {
 		Task {
 			do {
 				self.usetToken = try await AppleMusicAPI().fetchUserToken()
 				self.playlists = try await AppleMusicAPI().fetchPlaylists(userToken: usetToken)
-				self.mySongs = try await AppleMusicAPI().fetchSongs(userToken: usetToken, id: playlists[0].id)
-                print("완료")
+				self.mySongs = try await AppleMusicAPI().fetchMySongs(userToken: usetToken, id: playlists[0].id)
+			} catch NetworkError.invalidURL {
+				print("Invalid URL ERROR!")
+			}
+		}
+	}
+	
+	func fetchSongs(playlistId: String) {
+		Task {
+			do {
+				self.songs = try await AppleMusicAPI().fetchSongs(userToken: usetToken, id: playlistId)
 			} catch NetworkError.invalidURL {
 				print("Invalid URL ERROR!")
 			}

--- a/Mapli/Mapli/Sources/Extension/UIImage+.swift
+++ b/Mapli/Mapli/Sources/Extension/UIImage+.swift
@@ -8,7 +8,7 @@
 import UIKit
 
 extension UIImage {
-	public func withRoundedCorners(radius: CGFloat? = nil) -> UIImage? {
+	func withRoundedCorners(radius: CGFloat? = nil) -> UIImage? {
 		let maxRadius = min(size.width, size.height) / 2
 		let cornerRadius: CGFloat
 		if let radius = radius, radius > 0 && radius <= maxRadius {

--- a/Mapli/Mapli/Sources/Extension/UIImageView+.swift
+++ b/Mapli/Mapli/Sources/Extension/UIImageView+.swift
@@ -13,7 +13,7 @@ extension UIImageView {
 			if let data = try? Data(contentsOf: url) {
 				if let image = UIImage(data: data) {
 					DispatchQueue.main.async {
-						self?.image = image
+						self?.image = image.withRoundedCorners(radius: 20)
 					}
 				}
 			}

--- a/Mapli/Mapli/Sources/Extension/UIImageView+.swift
+++ b/Mapli/Mapli/Sources/Extension/UIImageView+.swift
@@ -1,0 +1,22 @@
+//
+//  UIImageView=.swift
+//  Mapli
+//
+//  Created by woo0 on 2022/08/05.
+//
+
+import UIKit
+
+extension UIImageView {
+	func load(url: URL) {
+		DispatchQueue.global().async { [weak self] in
+			if let data = try? Data(contentsOf: url) {
+				if let image = UIImage(data: data) {
+					DispatchQueue.main.async {
+						self?.image = image
+					}
+				}
+			}
+		}
+	}
+}

--- a/Mapli/Mapli/Sources/Models/DeviceSize.swift
+++ b/Mapli/Mapli/Sources/Models/DeviceSize.swift
@@ -12,6 +12,8 @@ enum DeviceSize {
 	static let topPaddong = UIScreen.main.proDevice ? 40 : 15
 	static let fontSize = UIScreen.main.proDevice ? 17 : 15
 	static let playlistImageSize = UIScreen.main.proDevice ? 170 : 155
+	static let playlistPadding = UIScreen.main.proDevice ? 20 : 25
+	static let playlistSpacing = UIScreen.main.proDevice ? 10 : 15
 	static let templatesWidth = UIScreen.main.proDevice ? 210 : 183
 	static let templatesHeight = UIScreen.main.proDevice ? 309 : 269
 }

--- a/Mapli/Mapli/Sources/Models/MySongModel.swift
+++ b/Mapli/Mapli/Sources/Models/MySongModel.swift
@@ -9,5 +9,9 @@ import Foundation
 
 struct MySong {
 	var title: String
+	var imageURL: String
+	var id: String
+	var width: Int
+	var height: Int
 	var isCheck: Bool
 }

--- a/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
@@ -12,7 +12,8 @@ class AppleMusicPlaylistViewController: UIViewController {
     @IBOutlet weak private var collectionView: UICollectionView!
 	
 	private var cancelBag = Set<AnyCancellable>()
-	private var songs = [Song]()
+	private var songs = [[MySong]]()
+	private var songsImage = [MySong]()
 	private var viewModel = AppleMusicViewModel()
     
     override func viewDidLoad() {
@@ -36,7 +37,6 @@ class AppleMusicPlaylistViewController: UIViewController {
 	
 	@objc private func updateUI(refresh: UIRefreshControl) {
 		refresh.endRefreshing()
-		songs = viewModel.songs
 		collectionView.reloadData()
 	}
     
@@ -51,9 +51,8 @@ class AppleMusicPlaylistViewController: UIViewController {
 
 }
 
-extension AppleMusicPlaylistViewController: UICollectionViewDataSource {
+extension AppleMusicPlaylistViewController: UICollectionViewDataSource, UICollectionViewDelegate {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        
         if viewModel.playlists.count == 0 {
             let label = UILabel()
             label.text = "Apple Music 앱에서\n플레이리스트를 추가해주세요.\n\n\n\n\n\n\n"
@@ -62,23 +61,26 @@ extension AppleMusicPlaylistViewController: UICollectionViewDataSource {
             label.textColor = .gray
             collectionView.backgroundView = label
         }
-        
         return viewModel.playlists.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         if let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "AppleMusicPlaylistCell", for: indexPath) as? AppleMusicPlaylistCollectionViewCell {
-			if !songs.isEmpty {
-				var url = songs[0].attributes.artwork.url
-				url = url.replacingOccurrences(of: "{w}", with: "\(songs[0].attributes.artwork.width)")
-				url = url.replacingOccurrences(of: "{h}", with: "\(songs[0].attributes.artwork.height)")
+			if songsImage.count == viewModel.playlists.count {
+				var url = songsImage[indexPath.item].imageURL
+				url = url.replacingOccurrences(of: "{w}", with: "\(songsImage[indexPath.item].width)")
+				url = url.replacingOccurrences(of: "{h}", with: "\(songsImage[indexPath.item].height)")
 
 				if URL(string: url) != nil {
 					cell.playlistImage.load(url: URL(string: url)!)
 				}
+				
+				for playlist in viewModel.playlists {
+					if playlist.id == songsImage[indexPath.item].id {
+						cell.playlistLabel.text = playlist.attributes.name
+					}
+				}
 			}
-			cell.playlistLabel.text = viewModel.playlists[indexPath.item].attributes.name
-            
             return cell
         } else {
             return UICollectionViewCell()
@@ -86,26 +88,27 @@ extension AppleMusicPlaylistViewController: UICollectionViewDataSource {
     }
 }
 
-extension AppleMusicPlaylistViewController: UICollectionViewDelegate {
-    
-}
-
 private extension AppleMusicPlaylistViewController {
 	func setupViewModel() {
 		viewModel.$playlists
 			.receive(on: DispatchQueue.main)
 			.sink { [weak self] playlist in
+				for list in playlist {
+					self?.viewModel.fetchMySong(playlistId: list.id)
+				}
 				if !playlist.isEmpty {
-					self?.viewModel.fetchSongs(playlistId: "\(playlist[0].id)")
 					self?.collectionView.backgroundView = nil
 				}
 			}
 			.store(in: &cancelBag)
 		
-		viewModel.$songs
+		viewModel.$mySongs
 			.receive(on: DispatchQueue.main)
 			.sink { [weak self] song in
-				self?.songs = song
+				if !song.isEmpty {
+					self?.songsImage.append(MySong(title: song[0].title, imageURL: song[0].imageURL, id: song[0].id, width: song[0].width, height: song[0].height, isCheck: song[0].isCheck))
+				}
+				self?.songs.append(song)
 				self?.collectionView.reloadData()
 			}
 			.store(in: &cancelBag)

--- a/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
@@ -49,6 +49,9 @@ class AppleMusicPlaylistViewController: UIViewController {
     private func setupCollectionView() {
         collectionView.dataSource = self
         collectionView.delegate = self
+		collectionView.translatesAutoresizingMaskIntoConstraints = false
+		collectionView.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: CGFloat(DeviceSize.playlistPadding)).isActive = true
+		collectionView.trailingAnchor.constraint(equalTo: view.trailingAnchor, constant: CGFloat(DeviceSize.playlistPadding)).isActive = true
     }
 	
 	private func initRefresh() {
@@ -113,6 +116,10 @@ extension AppleMusicPlaylistViewController: UICollectionViewDataSource, UICollec
 	
 	func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
 		return CGSize(width: DeviceSize.playlistImageSize, height: DeviceSize.playlistImageSize+27)
+	}
+	
+	func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, minimumInteritemSpacingForSectionAt section: Int) -> CGFloat {
+		return CGFloat(DeviceSize.playlistSpacing)
 	}
 }
 

--- a/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
@@ -18,10 +18,33 @@ class AppleMusicPlaylistViewController: UIViewController {
     
     override func viewDidLoad() {
         super.viewDidLoad()
+		setupNavigatoinBar()
         setupCollectionView()
 		setupViewModel()
 		initRefresh()
     }
+	
+	override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
+		if segue.identifier == "SongSelectionSegue" {
+			let cell = sender as? AppleMusicPlaylistCollectionViewCell ?? UICollectionViewCell()
+			let indexPath = collectionView.indexPath(for: cell)
+			if let SongSelectionViewController = segue.destination as? SongSelectionViewController {
+				if let indexPath = indexPath {
+					SongSelectionViewController.musicList = songs[indexPath.item+1]
+				}
+			}
+			
+		}
+	}
+	
+	private func setupNavigatoinBar() {
+		let backButton = UIBarButtonItem()
+		backButton.title = "이전"
+		navigationItem.backBarButtonItem = backButton
+		navigationController?.navigationBar.backIndicatorImage = UIImage()
+		navigationController?.navigationBar.backIndicatorTransitionMaskImage = UIImage()
+		navigationController?.navigationBar.tintColor = .red
+	}
 	
     private func setupCollectionView() {
         collectionView.dataSource = self

--- a/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
@@ -13,8 +13,7 @@ class AppleMusicPlaylistViewController: UIViewController {
 	
 	private var cancelBag = Set<AnyCancellable>()
 	private var songs = [Song]()
-	
-	var viewModel = AppleMusicViewModel()
+	private var viewModel = AppleMusicViewModel()
     
     override func viewDidLoad() {
         super.viewDidLoad()

--- a/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
@@ -74,7 +74,7 @@ class AppleMusicPlaylistViewController: UIViewController {
 
 }
 
-extension AppleMusicPlaylistViewController: UICollectionViewDataSource, UICollectionViewDelegate {
+extension AppleMusicPlaylistViewController: UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
         if viewModel.playlists.count == 0 {
             let label = UILabel()
@@ -96,6 +96,7 @@ extension AppleMusicPlaylistViewController: UICollectionViewDataSource, UICollec
 
 				if URL(string: url) != nil {
 					cell.playlistImage.load(url: URL(string: url)!)
+					cell.playlistImage.layer.cornerRadius = 20
 				}
 				
 				for playlist in viewModel.playlists {
@@ -109,6 +110,10 @@ extension AppleMusicPlaylistViewController: UICollectionViewDataSource, UICollec
             return UICollectionViewCell()
         }
     }
+	
+	func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
+		return CGSize(width: DeviceSize.playlistImageSize, height: DeviceSize.playlistImageSize+27)
+	}
 }
 
 private extension AppleMusicPlaylistViewController {

--- a/Mapli/Mapli/Sources/ViewControllers/ChooseTemplateViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/ChooseTemplateViewController.swift
@@ -30,8 +30,6 @@ class ChooseTemplateViewController: UIViewController {
 		setupImagePicker()
 		setupNavigationBar()
 		setupCollectionView()
-		print(selectedMusicList)
-		imagePickerButton.layer.cornerRadius = 20
 	}
 	
 	@IBAction func imagePickerButtonTapped(_ sender: UIButton) {
@@ -70,6 +68,7 @@ class ChooseTemplateViewController: UIViewController {
 	}
 	
 	private func setupImagePicker() {
+		imagePickerButton.layer.cornerRadius = 20
 		imagePicker.sourceType = .photoLibrary
 		imagePicker.allowsEditing = true
 		imagePicker.delegate = self

--- a/Mapli/Mapli/Sources/ViewControllers/ChooseTemplateViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/ChooseTemplateViewController.swift
@@ -79,7 +79,7 @@ class ChooseTemplateViewController: UIViewController {
 	}
 }
 
-extension ChooseTemplateViewController: UICollectionViewDataSource {
+extension ChooseTemplateViewController: UICollectionViewDataSource, UICollectionViewDelegate {
 	func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
 		return templatesList.count
 	}
@@ -112,10 +112,6 @@ extension ChooseTemplateViewController: UICollectionViewDataSource {
 			selectedTemplates = "\(cell.imageName)"
 		}
 	}
-}
-
-extension ChooseTemplateViewController: UICollectionViewDelegate {
-	
 }
 
 extension ChooseTemplateViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {

--- a/Mapli/Mapli/Sources/ViewControllers/ChooseTemplateViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/ChooseTemplateViewController.swift
@@ -20,6 +20,8 @@ class ChooseTemplateViewController: UIViewController {
 	private var templatesList = ["templates1", "templates2", "templates3", "templates4", "templates5"]
 	private var selectedTemplates = "templates1"
 	
+	var selectedMusicList = [String]()
+	
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		setupConstraint()
@@ -28,7 +30,7 @@ class ChooseTemplateViewController: UIViewController {
 		setupImagePicker()
 		setupNavigationBar()
 		setupCollectionView()
-		
+		print(selectedMusicList)
 		imagePickerButton.layer.cornerRadius = 20
 	}
 	

--- a/Mapli/Mapli/Sources/ViewControllers/MainViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/MainViewController.swift
@@ -10,20 +10,11 @@ import UIKit
 class MainViewController: UIViewController {
     @IBOutlet weak private var collectionView: UICollectionView!
     
-    var viewModel = AppleMusicViewModel()
-    
-	override func viewDidLoad() {
+    override func viewDidLoad() {
 		super.viewDidLoad()
 		setupNavigatoinBar()
         setupCollectionView()
 	}
-    
-    override func prepare(for segue: UIStoryboardSegue,sender: Any?){
-        if segue.identifier == "segue" {
-            let viewController = segue.destination as! AppleMusicPlaylistViewController
-            viewController.viewModel = viewModel
-        }
-    }
     
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)

--- a/Mapli/Mapli/Sources/ViewControllers/MainViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/MainViewController.swift
@@ -25,14 +25,6 @@ class MainViewController: UIViewController {
         }
     }
     
-    @IBAction func addButtonTapped(_ sender: UIBarButtonItem) {
-//        guard let viewController = self.storyboard?.instantiateViewController(withIdentifier: "AppleMusicPlaylistViewController") as? AppleMusicPlaylistViewController else { return }
-//
-//        viewController.viewModel = viewModel
-//
-//        self.navigationController?.pushViewController(viewController, animated: true)
-    }
-    
     override func viewWillAppear(_ animated: Bool) {
         super.viewWillAppear(animated)
     }

--- a/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
@@ -124,7 +124,7 @@ class SongSelectionViewController: UIViewController {
 	}
 }
 
-extension SongSelectionViewController: UITableViewDataSource {
+extension SongSelectionViewController: UITableViewDataSource, UITableViewDelegate {
 	func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
 		return isFiltering ? searchMusicList.count : musicList.count
 	}
@@ -166,10 +166,6 @@ extension SongSelectionViewController: UITableViewDataSource {
 			}
 		}
 	}
-}
-
-extension SongSelectionViewController: UITableViewDelegate {
-	
 }
 
 extension SongSelectionViewController: UISearchResultsUpdating {

--- a/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
@@ -113,10 +113,17 @@ class SongSelectionViewController: UIViewController {
 		refresh.endRefreshing()
 		self.tableView.reloadData()
 	}
-    
+	
 	@objc private func nextButtonTapped() {
-		let chooseTemplateVC = self.storyboard?.instantiateViewController(withIdentifier: "ChooseTemplateVC") ?? UIViewController()
-		self.navigationController?.pushViewController(chooseTemplateVC, animated: true)
+		let selectedMySongList = musicList.filter { $0.isCheck }
+		let selectedMusicList = selectedMySongList.map { $0.title }
+		if !selectedMusicList.isEmpty {
+			let chooseTemplateVC = self.storyboard?.instantiateViewController(withIdentifier: "ChooseTemplateVC") as! ChooseTemplateViewController
+			chooseTemplateVC.selectedMusicList = selectedMusicList
+			self.navigationController?.pushViewController(chooseTemplateVC, animated: true)
+		} else {
+			showToastMessage("최소 1곡 이상 선택해주세요.")
+		}
 	}
 }
 
@@ -170,5 +177,28 @@ extension SongSelectionViewController: UISearchResultsUpdating {
 		searchMusicList = musicList.filter { return $0.title.localizedCaseInsensitiveContains(text) }
 		
 		tableView.reloadData()
+	}
+}
+
+extension SongSelectionViewController {
+	func showToastMessage(_ message: String, font: UIFont = UIFont.systemFont(ofSize: 12, weight: .light)) {
+		let toastLabel = UILabel(frame: CGRect(x: view.frame.width / 2 - 150, y: view.frame.height - 120, width: 300, height: 50))
+		
+		toastLabel.backgroundColor = UIColor.black.withAlphaComponent(0.7)
+		toastLabel.textColor = UIColor.white
+		toastLabel.numberOfLines = 2
+		toastLabel.font = font
+		toastLabel.text = message
+		toastLabel.textAlignment = .center
+		toastLabel.layer.cornerRadius = 10
+		toastLabel.clipsToBounds = true
+		
+		self.view.addSubview(toastLabel)
+
+		UIView.animate(withDuration: 1.5, delay: 0.7, options: .curveEaseOut) {
+			toastLabel.alpha = 0.0
+		} completion: { _ in
+			toastLabel.removeFromSuperview()
+		}
 	}
 }

--- a/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
@@ -29,7 +29,6 @@ class SongSelectionViewController: UIViewController {
 		setupTableView()
 		setupNavigatoinBar()
 		initRefresh()
-		print(musicList)
 	}
 	
 	@IBAction func searchButtonTapped(_ sender: UIButton) {

--- a/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
@@ -12,8 +12,6 @@ class SongSelectionViewController: UIViewController {
 	@IBOutlet weak var searchButton: UIButton!
 	@IBOutlet weak var selectAllButton: UIButton!
 	
-	private let viewModel = AppleMusicViewModel()
-	
 	private var isFiltering: Bool {
 		let searchController = self.navigationItem.searchController
 		let isActive = searchController?.isActive ?? false
@@ -21,8 +19,9 @@ class SongSelectionViewController: UIViewController {
 		return isActive && isSearchText
 	}
 	private var isSearchBar = false
-	private var musicList = [MySong]()
 	private var searchMusicList = [MySong]()
+	
+	var musicList = [MySong]()
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -30,7 +29,7 @@ class SongSelectionViewController: UIViewController {
 		setupTableView()
 		setupNavigatoinBar()
 		initRefresh()
-		
+		print(musicList)
 	}
 	
 	@IBAction func searchButtonTapped(_ sender: UIButton) {
@@ -113,8 +112,6 @@ class SongSelectionViewController: UIViewController {
 	
 	@objc private func updateUI(refresh: UIRefreshControl) {
 		refresh.endRefreshing()
-		viewModel.viewDidLoad()
-		musicList = viewModel.mySongs
 		self.tableView.reloadData()
 	}
     


### PR DESCRIPTION
### 작업사항
- FetchSongs
- CollectionView 수정
- MySong Model 수정
- SongSelectionViewController MyMusic 수정
- ViewModel 수정
- Navigation Back Button 수정

### 비고 및 한계
- Combine으로 데이터를 fetch하다 보니 플레이리스트의 크기가 작은 것부터 가져오기 때문에 CollectionView에 보여지는 플레이리스트 순서와 실제 AppleMusic의 플레이리스트 순서가 다를 수 있습니다.
- CollectionView의 BackgroundView(emptyView)에서 AppleMusic으로 이동하는 기능은 추후 라우가 구현 예정