### PR TITLE
대표이미지 선택지추가

### DIFF
--- a/Mapli/Mapli.xcodeproj/project.pbxproj
+++ b/Mapli/Mapli.xcodeproj/project.pbxproj
@@ -536,6 +536,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mapli/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Apple Music 접근 권한";
+				INFOPLIST_KEY_NSCameraUsageDescription = "대표 이미지 추가를 위한 카메라 접근 권한";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "대표 이미지 추가를 위한 앨범 접근 권한";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;
@@ -569,6 +570,7 @@
 				GENERATE_INFOPLIST_FILE = YES;
 				INFOPLIST_FILE = Mapli/Info.plist;
 				INFOPLIST_KEY_NSAppleMusicUsageDescription = "Apple Music 접근 권한";
+				INFOPLIST_KEY_NSCameraUsageDescription = "대표 이미지 추가를 위한 카메라 접근 권한";
 				INFOPLIST_KEY_NSPhotoLibraryUsageDescription = "대표 이미지 추가를 위한 앨범 접근 권한";
 				INFOPLIST_KEY_UIApplicationSupportsIndirectInputEvents = YES;
 				INFOPLIST_KEY_UILaunchStoryboardName = LaunchScreen;

--- a/Mapli/Mapli.xcodeproj/project.pbxproj
+++ b/Mapli/Mapli.xcodeproj/project.pbxproj
@@ -36,7 +36,7 @@
 		E219443B28957665005BE37B /* PlaylistModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E219443A28957665005BE37B /* PlaylistModel.swift */; };
 		E219443D28957670005BE37B /* AppleMusicAPI.swift in Sources */ = {isa = PBXBuildFile; fileRef = E219443C28957670005BE37B /* AppleMusicAPI.swift */; };
 		E2194442289577AB005BE37B /* Mapli++Bundle.swift in Sources */ = {isa = PBXBuildFile; fileRef = E2194441289577AB005BE37B /* Mapli++Bundle.swift */; };
-		E21944442896735F005BE37B /* MySongModel.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21944432896735F005BE37B /* MySongModel.swift */; };
+		E21944442896735F005BE37B /* AppleMusicPlayList.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21944432896735F005BE37B /* AppleMusicPlayList.swift */; };
 		E21944462896A6AE005BE37B /* ChooseTemplateStoryboard.storyboard in Resources */ = {isa = PBXBuildFile; fileRef = E21944452896A6AE005BE37B /* ChooseTemplateStoryboard.storyboard */; };
 		E21944482896A6C6005BE37B /* ChooseTemplateViewController.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21944472896A6C6005BE37B /* ChooseTemplateViewController.swift */; };
 		E21D9964288ABA580065CB2A /* AppDelegate.swift in Sources */ = {isa = PBXBuildFile; fileRef = E21D9963288ABA580065CB2A /* AppDelegate.swift */; };
@@ -88,7 +88,7 @@
 		E219443A28957665005BE37B /* PlaylistModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = PlaylistModel.swift; path = Mapli/Sources/Models/PlaylistModel.swift; sourceTree = SOURCE_ROOT; };
 		E219443C28957670005BE37B /* AppleMusicAPI.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; name = AppleMusicAPI.swift; path = Mapli/Sources/Classes/AppleMusicAPI.swift; sourceTree = SOURCE_ROOT; };
 		E2194441289577AB005BE37B /* Mapli++Bundle.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = "Mapli++Bundle.swift"; sourceTree = "<group>"; };
-		E21944432896735F005BE37B /* MySongModel.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = MySongModel.swift; sourceTree = "<group>"; };
+		E21944432896735F005BE37B /* AppleMusicPlayList.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = AppleMusicPlayList.swift; sourceTree = "<group>"; };
 		E21944452896A6AE005BE37B /* ChooseTemplateStoryboard.storyboard */ = {isa = PBXFileReference; lastKnownFileType = file.storyboard; path = ChooseTemplateStoryboard.storyboard; sourceTree = "<group>"; };
 		E21944472896A6C6005BE37B /* ChooseTemplateViewController.swift */ = {isa = PBXFileReference; lastKnownFileType = sourcecode.swift; path = ChooseTemplateViewController.swift; sourceTree = "<group>"; };
 		E21D9960288ABA580065CB2A /* Mapli.app */ = {isa = PBXFileReference; explicitFileType = wrapper.application; includeInIndex = 0; path = Mapli.app; sourceTree = BUILT_PRODUCTS_DIR; };
@@ -213,7 +213,7 @@
 				E2821A582897F2CB00982AE7 /* DeviceSize.swift */,
 				E219443828957657005BE37B /* SongModel.swift */,
 				E219443A28957665005BE37B /* PlaylistModel.swift */,
-				E21944432896735F005BE37B /* MySongModel.swift */,
+				E21944432896735F005BE37B /* AppleMusicPlayList.swift */,
 				E2AD46C3289BA4AC00E513B7 /* TemplatesModel.swift */,
 				0A091E2B28A0FE7800680E8D /* MyPlayListModel.swift */,
 			);
@@ -379,7 +379,7 @@
 				E2821A5C2897FB6800982AE7 /* UIScreen+.swift in Sources */,
 				0A091E4028A54A6B00680E8D /* UIFont+.swift in Sources */,
 				E21944482896A6C6005BE37B /* ChooseTemplateViewController.swift in Sources */,
-				E21944442896735F005BE37B /* MySongModel.swift in Sources */,
+				E21944442896735F005BE37B /* AppleMusicPlayList.swift in Sources */,
 				E2821A542896F4A300982AE7 /* AppleMusicViewModel.swift in Sources */,
 				0A091E2E28A11ACC00680E8D /* ImageDataManager.swift in Sources */,
 				E21D9966288ABA580065CB2A /* SceneDelegate.swift in Sources */,

--- a/Mapli/Mapli/Info.plist
+++ b/Mapli/Mapli/Info.plist
@@ -2,6 +2,10 @@
 <!DOCTYPE plist PUBLIC "-//Apple//DTD PLIST 1.0//EN" "http://www.apple.com/DTDs/PropertyList-1.0.dtd">
 <plist version="1.0">
 <dict>
+	<key>LSApplicationQueriesSchemes</key>
+	<array>
+		<string>applemusic</string>
+	</array>
 	<key>UIAppFonts</key>
 	<array>
 		<string>ChosunCentennial_otf.otf</string>
@@ -15,10 +19,6 @@
 		<string>UhBee mysen Bold.ttf</string>
 		<string>UhBee mysen.ttf</string>
 		<string>UhBee Seulvely.ttf</string>
-	</array>
-	<key>LSApplicationQueriesSchemes</key>
-	<array>
-		<string>applemusic</string>
 	</array>
 	<key>UIApplicationSceneManifest</key>
 	<dict>

--- a/Mapli/Mapli/Resources/Storyboards/ChooseTemplateStoryboard.storyboard
+++ b/Mapli/Mapli/Resources/Storyboards/ChooseTemplateStoryboard.storyboard
@@ -34,7 +34,7 @@
                                 <nil key="textColor"/>
                                 <nil key="highlightedColor"/>
                             </label>
-                            <button opaque="NO" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fu0-fc-mJ1">
+                            <button opaque="NO" clipsSubviews="YES" contentMode="scaleAspectFit" contentHorizontalAlignment="center" contentVerticalAlignment="center" buttonType="system" lineBreakMode="middleTruncation" translatesAutoresizingMaskIntoConstraints="NO" id="fu0-fc-mJ1">
                                 <rect key="frame" x="20" y="220" width="170" height="170"/>
                                 <color key="backgroundColor" red="0.93288300555161752" green="0.93288300555161752" blue="0.93288300555161752" alpha="1" colorSpace="custom" customColorSpace="displayP3"/>
                                 <constraints>

--- a/Mapli/Mapli/Sources/Models/AppleMusicPlayList.swift
+++ b/Mapli/Mapli/Sources/Models/AppleMusicPlayList.swift
@@ -6,6 +6,13 @@
 //
 
 import Foundation
+import UIKit
+
+struct AppleMusicPlayList {
+    var playListImage: UIImage? = nil
+    var songs: [MySong]
+    var songsString: [String]? = nil
+}
 
 struct MySong {
 	var title: String

--- a/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/AppleMusicPlaylistViewController.swift
@@ -24,13 +24,15 @@ class AppleMusicPlaylistViewController: UIViewController {
 		initRefresh()
     }
 	
+    // 네트워킹 다 안끝났을때 누르면 고장남. 예외 처리 필요.
 	override func prepare(for segue: UIStoryboardSegue, sender: Any?) {
 		if segue.identifier == "SongSelectionSegue" {
-			let cell = sender as? AppleMusicPlaylistCollectionViewCell ?? UICollectionViewCell()
+            guard let cell = sender as? AppleMusicPlaylistCollectionViewCell else { return }
+            guard let playListImage = cell.playlistImage.image else { return }
 			let indexPath = collectionView.indexPath(for: cell)
 			if let SongSelectionViewController = segue.destination as? SongSelectionViewController {
 				if let indexPath = indexPath {
-					SongSelectionViewController.musicList = songs[indexPath.item+1]
+                    SongSelectionViewController.appleMusicPlayList = AppleMusicPlayList(playListImage: playListImage, songs: songs[indexPath.item + 1])
 				}
 			}
 			

--- a/Mapli/Mapli/Sources/ViewControllers/ChooseTemplateViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/ChooseTemplateViewController.swift
@@ -14,13 +14,11 @@ class ChooseTemplateViewController: UIViewController {
 	@IBOutlet weak var imagePickerButton: UIButton!
 	@IBOutlet weak var templateTitleLabel: UILabel!
 	@IBOutlet weak private var collectionView: UICollectionView!
-	
+    
 	private let imagePicker = UIImagePickerController()
-
     private var templatesList = [TemplatesModel(imageName: .templates1, isCheck: false), TemplatesModel(imageName: .templates2, isCheck: false), TemplatesModel(imageName: .templates3, isCheck: false), TemplatesModel(imageName: .templates4, isCheck: false), TemplatesModel(imageName: .templates5, isCheck: false)]
 	private var selectedTemplates: TemplatesModel?
-	
-	var selectedMusicList = [String]()
+    var selectedMusicList: AppleMusicPlayList!
 	
 	override func viewDidLoad() {
 		super.viewDidLoad()
@@ -41,7 +39,11 @@ class ChooseTemplateViewController: UIViewController {
             self.openLibrary()
         }
         let defaultImageAction =  UIAlertAction(title: "플레이리스트 이미지 사용", style: UIAlertAction.Style.default){_ in
-            
+            DispatchQueue.main.async {
+                guard let image = self.selectedMusicList.playListImage else { return }
+                let resizedImage = self.resize(image: image, width: self.imagePickerButton.frame.size.width, height: self.imagePickerButton.frame.size.height)
+                self.imagePickerButton.setImage(resizedImage, for: .normal)
+            }
         }
         let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel) {_ in
             self.dismiss(animated: true)
@@ -89,7 +91,7 @@ class ChooseTemplateViewController: UIViewController {
 	
 	private func setupImagePicker() {
 		imagePickerButton.layer.cornerRadius = 20
-		imagePicker.sourceType = .photoLibrary
+        imagePicker.sourceType = .photoLibrary
 		imagePicker.allowsEditing = true
 		imagePicker.delegate = self
 	}
@@ -185,7 +187,7 @@ extension ChooseTemplateViewController: UIImagePickerControllerDelegate, UINavig
 		imagePickerButton.setTitle("", for: .normal)
 		newImage = resize(image: newImage ?? UIImage(), width: imagePickerButton.frame.size.width, height: imagePickerButton.frame.size.height)
 		newImage = newImage?.withRoundedCorners(radius: 20)
-		imagePickerButton.setImage(newImage, for: .normal)
+        imagePickerButton.setImage(newImage, for: .normal)
 		imagePickerButton.imageView?.contentMode = .scaleAspectFit
 		imagePickerButton.semanticContentAttribute = .forceRightToLeft
 		picker.dismiss(animated: true, completion: nil)

--- a/Mapli/Mapli/Sources/ViewControllers/ChooseTemplateViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/ChooseTemplateViewController.swift
@@ -33,8 +33,25 @@ class ChooseTemplateViewController: UIViewController {
 	}
 	
 	@IBAction func imagePickerButtonTapped(_ sender: UIButton) {
-		present(imagePicker, animated: true)
-	}
+        let actionSheet = UIAlertController(title: "대표 이미지 선택", message: nil, preferredStyle: UIAlertController.Style.actionSheet)
+        let cameraAction =  UIAlertAction(title: "사진 촬영", style: UIAlertAction.Style.default){_ in
+            self.openCamera()
+        }
+        let galleryAction =  UIAlertAction(title: "갤러리에서 선택", style: UIAlertAction.Style.default){_ in
+            self.openLibrary()
+        }
+        let defaultImageAction =  UIAlertAction(title: "플레이리스트 이미지 사용", style: UIAlertAction.Style.default){_ in
+            
+        }
+        let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel) {_ in
+            self.dismiss(animated: true)
+        }
+        actionSheet.addAction(cameraAction)
+        actionSheet.addAction(galleryAction)
+        actionSheet.addAction(defaultImageAction)
+        actionSheet.addAction(cancelAction)
+        self.present(actionSheet, animated: true)
+    }
 	
 	private func setupConstraint() {
 		titleLabel.translatesAutoresizingMaskIntoConstraints = false
@@ -83,11 +100,8 @@ class ChooseTemplateViewController: UIViewController {
 	}
     
     @objc private func nextButtonTapped() {
-        guard let title = titleTextField.text else {
-            if title == "" {
-                showToastMessage("제목을 입력해주세요.")
-                return
-            }
+        guard let title = titleTextField.text else { return }
+        if title == "" {
             showToastMessage("제목을 입력해주세요.")
             return
         }
@@ -145,6 +159,20 @@ extension ChooseTemplateViewController: UICollectionViewDataSource, UICollection
 }
 
 extension ChooseTemplateViewController: UIImagePickerControllerDelegate, UINavigationControllerDelegate {
+    func openCamera(){
+        if(UIImagePickerController .isSourceTypeAvailable(.camera)){
+            imagePicker.sourceType = .camera
+            present(imagePicker, animated: true, completion: nil)
+        } else {
+            print("Camera not available")
+        }
+    }
+    
+    func openLibrary(){
+        imagePicker.sourceType = .photoLibrary
+        present(imagePicker, animated: true, completion: nil)
+    }
+
 	func imagePickerController(_ picker: UIImagePickerController, didFinishPickingMediaWithInfo info: [UIImagePickerController.InfoKey : Any]) {
 		var newImage: UIImage? = nil
 		

--- a/Mapli/Mapli/Sources/ViewControllers/MyPlayListDetailedScreenViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/MyPlayListDetailedScreenViewController.swift
@@ -37,7 +37,7 @@ class MyPlayListDetailedScreenViewController: UIViewController {
         let destructiveAction = UIAlertAction(title: "삭제하기", style: UIAlertAction.Style.destructive){(_) in
             self.popRemoveAlert()
         }
-        let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.default) {_ in
+        let cancelAction = UIAlertAction(title: "취소", style: UIAlertAction.Style.cancel) {_ in
             self.dismiss(animated: true)
         }
         actionSheet.addAction(shareAction)

--- a/Mapli/Mapli/Sources/ViewControllers/PreviewMyPlayListViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/PreviewMyPlayListViewController.swift
@@ -13,7 +13,7 @@ class PreviewMyPlayListViewController: UIViewController {
     @IBOutlet var templateCollectionViewBottomConstraint: NSLayoutConstraint!
     
     var myPlayListModel: MyPlayListModel? = nil
-    var selectedMusicList = [String]()
+    var selectedMusicList: AppleMusicPlayList!
 
     override func viewDidLoad() {
         super.viewDidLoad()
@@ -71,13 +71,15 @@ class PreviewMyPlayListViewController: UIViewController {
 
 extension PreviewMyPlayListViewController: UICollectionViewDataSource, UICollectionViewDelegate, UICollectionViewDelegateFlowLayout {
     func collectionView(_ collectionView: UICollectionView, numberOfItemsInSection section: Int) -> Int {
-        return selectedMusicList.count
+        guard let songs = selectedMusicList.songsString else { return 0 }
+        return songs.count
     }
     
     func collectionView(_ collectionView: UICollectionView, cellForItemAt indexPath: IndexPath) -> UICollectionViewCell {
         guard let cell = collectionView.dequeueReusableCell(withReuseIdentifier: "PreviewMyPlayListCollectionViewCell", for: indexPath) as? PreviewMyPlayListCollectionViewCell else { return UICollectionViewCell() }
-        guard let myPlayListModel = myPlayListModel else { return cell}
-        let musicTitle = selectedMusicList[indexPath.item]
+        guard let myPlayListModel = myPlayListModel else { return cell }
+        guard let songs = selectedMusicList.songsString else { return cell }
+        let musicTitle = songs[indexPath.item]
         DispatchQueue.main.async {
             cell.selectedTemplate = myPlayListModel.template
             cell.setUI(musicTitle)

--- a/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
@@ -21,8 +21,8 @@ class SongSelectionViewController: UIViewController {
 	private var isSearchBar = false
 	private var searchMusicList = [MySong]()
 	
-	var musicList = [MySong]()
-	
+    var appleMusicPlayList: AppleMusicPlayList!
+    
 	override func viewDidLoad() {
 		super.viewDidLoad()
 		setupConstraint()
@@ -48,7 +48,7 @@ class SongSelectionViewController: UIViewController {
 	@IBAction func selectAllButtonTapped(_ sender: UIButton) {
 		if CheckIfSelected() {
 			for row in 0..<tableView.numberOfRows(inSection: 0) {
-				musicList[row].isCheck = false
+                appleMusicPlayList.songs[row].isCheck = false
 				tableView.reloadData()
 			}
 		} else {
@@ -56,8 +56,8 @@ class SongSelectionViewController: UIViewController {
 				let indexPath = IndexPath(row: row, section: 0)
 				if let cell = tableView.cellForRow(at: indexPath) as? SongSelectionTableViewCell {
 					cell.selectionStyle = .none
-					musicList[indexPath.row].isCheck.toggle()
-					cell.checkmark.image = (musicList[indexPath.row].isCheck) ? UIImage(named: "Selected") : UIImage(named: "UnSelected")
+                    appleMusicPlayList.songs[indexPath.row].isCheck.toggle()
+                    cell.checkmark.image = (appleMusicPlayList.songs[indexPath.row].isCheck) ? UIImage(named: "Selected") : UIImage(named: "UnSelected")
 				}
 			}
 		}
@@ -94,8 +94,8 @@ class SongSelectionViewController: UIViewController {
 	
 	private func CheckIfSelected() -> Bool {
 		var isSelected = false
-		for row in 0..<musicList.count {
-			if musicList[row].isCheck {
+        for row in 0 ..< appleMusicPlayList.songs.count {
+            if appleMusicPlayList.songs[row].isCheck {
 				isSelected = true
 			}
 		}
@@ -115,11 +115,12 @@ class SongSelectionViewController: UIViewController {
 	}
 	
 	@objc private func nextButtonTapped() {
-		let selectedMySongList = musicList.filter { $0.isCheck }
+        let selectedMySongList = appleMusicPlayList.songs.filter { $0.isCheck }
 		let selectedMusicList = selectedMySongList.map { $0.title }
 		if !selectedMusicList.isEmpty {
 			let chooseTemplateVC = self.storyboard?.instantiateViewController(withIdentifier: "ChooseTemplateVC") as! ChooseTemplateViewController
-			chooseTemplateVC.selectedMusicList = selectedMusicList
+            appleMusicPlayList.songsString = selectedMusicList
+			chooseTemplateVC.selectedMusicList = appleMusicPlayList
 			self.navigationController?.pushViewController(chooseTemplateVC, animated: true)
 		} else {
 			showToastMessage("최소 1곡 이상 선택해주세요.")
@@ -129,7 +130,7 @@ class SongSelectionViewController: UIViewController {
 
 extension SongSelectionViewController: UITableViewDataSource, UITableViewDelegate {
 	func tableView(_ tableView: UITableView, numberOfRowsInSection section: Int) -> Int {
-		return isFiltering ? searchMusicList.count : musicList.count
+        return isFiltering ? searchMusicList.count : appleMusicPlayList.songs.count
 	}
 	
 	func tableView(_ tableView: UITableView, cellForRowAt indexPath: IndexPath) -> UITableViewCell {
@@ -140,7 +141,7 @@ extension SongSelectionViewController: UITableViewDataSource, UITableViewDelegat
 				cell.songTitle.text = song.title
 				cell.checkmark.image = song.isCheck ? UIImage(named: "Selected") : UIImage(named: "UnSelected")
 			} else {
-				let song = musicList[indexPath.row]
+                let song = appleMusicPlayList.songs[indexPath.row]
 				cell.songTitle.text = song.title
 				cell.checkmark.image = song.isCheck ? UIImage(named: "Selected") : UIImage(named: "UnSelected")
 			}
@@ -156,16 +157,16 @@ extension SongSelectionViewController: UITableViewDataSource, UITableViewDelegat
 			cell.selectionStyle = .none
 			
 			if isFiltering {
-				if let row = self.musicList.firstIndex(where: { $0.title == searchMusicList[indexPath.row].title }) {
-					musicList[row].isCheck.toggle()
+                if let row = self.appleMusicPlayList.songs.firstIndex(where: { $0.title == searchMusicList[indexPath.row].title }) {
+                    appleMusicPlayList.songs[row].isCheck.toggle()
 				}
 				if let row = self.searchMusicList.firstIndex(where: { $0.title == searchMusicList[indexPath.row].title }) {
 					searchMusicList[row].isCheck.toggle()
 				}
 				cell.checkmark.image = searchMusicList[indexPath.row].isCheck ? UIImage(named: "Selected") : UIImage(named: "UnSelected")
 			} else {
-				musicList[indexPath.row].isCheck.toggle()
-				cell.checkmark.image = musicList[indexPath.row].isCheck ? UIImage(named: "Selected") : UIImage(named: "UnSelected")
+                appleMusicPlayList.songs[indexPath.row].isCheck.toggle()
+                cell.checkmark.image = appleMusicPlayList.songs[indexPath.row].isCheck ? UIImage(named: "Selected") : UIImage(named: "UnSelected")
 			}
 		}
 	}
@@ -174,7 +175,7 @@ extension SongSelectionViewController: UITableViewDataSource, UITableViewDelegat
 extension SongSelectionViewController: UISearchResultsUpdating {
 	func updateSearchResults(for searchController: UISearchController) {
 		guard let text = searchController.searchBar.text else { return }
-		searchMusicList = musicList.filter { return $0.title.localizedCaseInsensitiveContains(text) }
+        searchMusicList = appleMusicPlayList.songs.filter { return $0.title.localizedCaseInsensitiveContains(text) }
 		
 		tableView.reloadData()
 	}


### PR DESCRIPTION
## 작업내용
- 플꾸2화면에서 대표이미지 선택 시 갤러리에서 선택외에 사진찍기, 기존 플리이미지 사용하기 추가
- 리팩토링 (MySongModel -> AppleMusicPlayListModel)

## 전달 사항
- AppleMusicPlaylistViewController 에서 네트워킹 안끝났을때 플리 선택하면 앱 종료됨. 예외 처리 필요.
- 플꾸2 화면 사진 촬영하여 이미지 선택 시 resizing에 문제있음. 만나서 설명드림.