### PR TITLE
FIX/#33 SearchController 수정

### DIFF
--- a/Mapli/Mapli/Resources/Storyboards/SongSelectionStoryboard.storyboard
+++ b/Mapli/Mapli/Resources/Storyboards/SongSelectionStoryboard.storyboard
@@ -3,6 +3,7 @@
     <device id="retina6_0" orientation="portrait" appearance="light"/>
     <dependencies>
         <plugIn identifier="com.apple.InterfaceBuilder.IBCocoaTouchPlugin" version="20020"/>
+        <capability name="Image references" minToolsVersion="12.0"/>
         <capability name="Safe area layout guides" minToolsVersion="9.0"/>
         <capability name="System colors in document resources" minToolsVersion="11.0"/>
         <capability name="documents saved in the Xcode 8 format" minToolsVersion="8.0"/>
@@ -22,9 +23,11 @@
                                     <constraint firstAttribute="width" constant="24" id="Eiq-Hd-N4n"/>
                                     <constraint firstAttribute="height" constant="24" id="cjx-en-yJQ"/>
                                 </constraints>
+                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
                                 <color key="tintColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" title=" " image="magnifyingglass" catalog="system">
+                                <state key="normal" title=" ">
+                                    <imageReference key="image" image="magnifyingglass" catalog="system" symbolScale="large"/>
                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="17"/>
                                 </state>
                                 <connections>
@@ -37,10 +40,11 @@
                                     <constraint firstAttribute="width" constant="68" id="6pP-QO-np2"/>
                                     <constraint firstAttribute="height" constant="24" id="nzu-JS-pLR"/>
                                 </constraints>
-                                <fontDescription key="fontDescription" type="system" pointSize="12"/>
+                                <fontDescription key="fontDescription" type="system" pointSize="14"/>
                                 <inset key="imageEdgeInsets" minX="0.0" minY="0.0" maxX="2.2250738585072014e-308" maxY="0.0"/>
-                                <state key="normal" title="전체선택" image="checkmark" catalog="system">
+                                <state key="normal" title="전체선택">
                                     <color key="titleColor" white="0.0" alpha="1" colorSpace="custom" customColorSpace="genericGamma22GrayColorSpace"/>
+                                    <imageReference key="image" image="checkmark" catalog="system" symbolScale="medium"/>
                                     <preferredSymbolConfiguration key="preferredSymbolConfiguration" configurationType="pointSize" pointSize="17"/>
                                 </state>
                                 <connections>

--- a/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/SongSelectionViewController.swift
@@ -7,7 +7,7 @@
 
 import UIKit
 
-class SongSelectionViewController: UIViewController {
+class SongSelectionViewController: UIViewController, UISearchBarDelegate {
 	@IBOutlet weak var tableView: UITableView!
 	@IBOutlet weak var searchButton: UIButton!
 	@IBOutlet weak var selectAllButton: UIButton!
@@ -32,17 +32,16 @@ class SongSelectionViewController: UIViewController {
 	}
 	
 	@IBAction func searchButtonTapped(_ sender: UIButton) {
-		isSearchBar.toggle()
 		let searchController = UISearchController(searchResultsController: nil)
 		searchController.searchBar.placeholder = "노래 제목을 입력하세요."
 		searchController.searchResultsUpdater = self
+		searchController.searchBar.delegate = self
 		searchController.searchBar.setValue("취소", forKey: "cancelButtonText")
-		
-		if isSearchBar {
-			navigationItem.searchController = searchController
-		} else {
-			navigationItem.searchController = nil
+		navigationItem.searchController = searchController
+		DispatchQueue.main.async {
+			searchController.searchBar.searchTextField.becomeFirstResponder()
 		}
+		searchButton.isHidden = true
 	}
 	
 	@IBAction func selectAllButtonTapped(_ sender: UIButton) {
@@ -63,6 +62,11 @@ class SongSelectionViewController: UIViewController {
 		}
 	}
 	
+	func searchBarCancelButtonClicked(_ searchBar: UISearchBar) {
+		navigationItem.searchController = nil
+		searchButton.isHidden = false
+	}
+	
 	private func setupConstraint() {
 		self.searchButton.translatesAutoresizingMaskIntoConstraints = false
 		self.searchButton.leadingAnchor.constraint(equalTo: view.leadingAnchor, constant: CGFloat(DeviceSize.leadingPadding)).isActive = true
@@ -71,14 +75,6 @@ class SongSelectionViewController: UIViewController {
 	private func setupTableView() {
 		tableView.dataSource = self
 		tableView.delegate = self
-	}
-	
-	private func setupSearchController() {
-		let searchController = UISearchController(searchResultsController: nil)
-		searchController.searchBar.placeholder = "노래 제목을 입력하세요."
-		navigationItem.searchController = searchController
-		searchController.searchResultsUpdater = self
-		searchController.searchBar.setValue("취소", forKey: "cancelButtonText")
 	}
 	
 	private func setupNavigatoinBar() {


### PR DESCRIPTION
### 작업사항
- searchController enable 방식 수정
- searchController 호출 시 검색창에 포커스 이동
- searchController cancel action 추가

### 비고 및 한계
- searchController cancel 버튼 클릭 시 searchController를 중단하기 위해 navigationItem.searchController = nil 방식으로 구현했기 때문에 추후 문제가 발생 할 수 있음
- 다음 업데이트 때 다른 방법을 찾거나 UX에 대한 논의가 필요함 