### PR TITLE
[Fix] #80 템플릿 글씨 위치 수정

### DIFF
--- a/Mapli/Mapli/Sources/ViewControllers/PreviewMyPlayListViewController.swift
+++ b/Mapli/Mapli/Sources/ViewControllers/PreviewMyPlayListViewController.swift
@@ -16,12 +16,12 @@ class PreviewMyPlayListViewController: UIViewController {
     override func viewDidLoad() {
         super.viewDidLoad()
         DispatchQueue.main.async {
+            self.configureNavigationBar()
             self.setConstraint()
             self.configureImageView()
-            self.configureNavigationBar()
         }
     }
-    
+
     private func setConstraint() {
         templateCollectionView.translatesAutoresizingMaskIntoConstraints = false
         templateCollectionView.topAnchor.constraint(equalTo: view.safeAreaLayoutGuide.topAnchor,constant: CGFloat(UIScreen.getDevice().previewTopPadding)).isActive = true
@@ -29,18 +29,20 @@ class PreviewMyPlayListViewController: UIViewController {
         templateCollectionView.centerXAnchor.constraint(equalTo: view.centerXAnchor).isActive = true
         templateCollectionView.widthAnchor.constraint(equalToConstant: CGFloat(UIScreen.getDevice().previewImageViewWidth)).isActive = true
         templateCollectionView.heightAnchor.constraint(equalToConstant: CGFloat(UIScreen.getDevice().previewImageViewHeight)).isActive = true
-
-        guard let myPlayListModel = myPlayListModel else { return }
+        
         var insetMultiplier = CGFloat(1)
+        guard let songs = selectedMusicList.songsString else { return }
+        let songsCount = CGFloat(songs.count)
+        guard let myPlayListModel = myPlayListModel else { return }
         switch myPlayListModel.template {
         case .templates1:
-            insetMultiplier = 6
+            insetMultiplier = 4 + 0.2 * songsCount
         case .templates2:
-            insetMultiplier = 4
+            insetMultiplier = 3.2 + 0.2 * songsCount
         case .templates3:
-            insetMultiplier = 4
+            insetMultiplier = 3.2 + 0.2 * songsCount
         default:
-            insetMultiplier = 4.5
+            insetMultiplier = 3.7 + 0.2 * songsCount
         }
         templateCollectionView.contentInset.top = max((templateCollectionView.frame.height - templateCollectionView.contentSize.height) / insetMultiplier, 0)
     }
@@ -91,11 +93,11 @@ extension PreviewMyPlayListViewController: UICollectionViewDataSource, UICollect
         }
         return cell
     }
-    
+
     func collectionView(_ collectionView: UICollectionView, layout collectionViewLayout: UICollectionViewLayout, sizeForItemAt indexPath: IndexPath) -> CGSize {
         var widthMultiplier = 0.8
         var heightMultiplier = 0.05
-        
+
         guard let myPlayListModel = myPlayListModel else { return CGSize() }
         switch myPlayListModel.template {
         case .templates1:


### PR DESCRIPTION
노래 제목들이 중앙에서 조금 위에 놓이도록 수정하였습니다.

<img src="https://user-images.githubusercontent.com/74828662/192141052-424dc8aa-94b4-416b-9282-3e1975665bce.PNG" width="180" height="400"/> <img src="https://user-images.githubusercontent.com/74828662/192141045-848e10f0-75f2-42f3-ba7c-d29a5db6c8b8.PNG" width="180" height="400"/> <img src="https://user-images.githubusercontent.com/74828662/192141060-dd895493-d933-450a-98ed-2969c05c576f.PNG" width="180" height="400"/>
